### PR TITLE
Add support for MCMC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - conda config --set always_yes yes --set changeps1 no
     - conda create --yes -n test_env python="$TRAVIS_PYTHON_VERSION" gcc=4.8 numpy scipy nose pip wheel
     - source ~/miniconda/bin/activate test_env
-    - pip install ghp-import mkdocs coverage coveralls colorlog
+    - pip install ghp-import mkdocs coverage coveralls colorlog emcee
     - export LD_LIBRARY_PATH=~/miniconda/envs/test_env/lib
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
           pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.7.0-py2-none-linux_x86_64.whl;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tensorflow==0.7.0
 colorlog
+emcee

--- a/tensorprob/__init__.py
+++ b/tensorprob/__init__.py
@@ -34,3 +34,4 @@ from .model import Model, ModelError
 from .parameter import Parameter
 from .distributions import *
 from .optimizers import *
+from .samplers import *

--- a/tensorprob/distribution.py
+++ b/tensorprob/distribution.py
@@ -59,26 +59,9 @@ def Distribution(distribution_init):
         Distribution.bounds = lambda ndim: _parse_bounds(ndim, lower, upper, bounds)
         variables = distribution_init(*args, name=name)
 
-<<<<<<< 37ca5d3793ad4ccbd95f204831c49fa607bd2f49
         # One dimensional distributions return a value, convert it to a tuple
         if not isinstance(variables, tuple):
             variables = (variables,)
-=======
-        if lower is not None:
-            lower_ = tf.cast(lower, config.dtype)
-            Distribution.logp = tf.select(tf.less(variables, lower_),
-                    tf.fill(tf.shape(variables), tf.constant(-np.inf, dtype=config.dtype)),
-                    Distribution.logp)
-
-        if upper is not None:
-            upper_ = tf.cast(upper, config.dtype)
-            Distribution.logp = tf.select(tf.greater(variables, upper_),
-                    tf.fill(tf.shape(variables), tf.constant(-np.inf, dtype=config.dtype)),
-                    Distribution.logp)
-
-        if lower is not None and upper is not None:
-            Distribution.logp = Distribution.logp - tf.log(Distribution.integral(lower, upper))
->>>>>>> Add support for MCMC
 
         # Ensure the distribution has set the required properties
         if Distribution.logp is None:

--- a/tensorprob/distribution.py
+++ b/tensorprob/distribution.py
@@ -59,9 +59,26 @@ def Distribution(distribution_init):
         Distribution.bounds = lambda ndim: _parse_bounds(ndim, lower, upper, bounds)
         variables = distribution_init(*args, name=name)
 
+<<<<<<< 37ca5d3793ad4ccbd95f204831c49fa607bd2f49
         # One dimensional distributions return a value, convert it to a tuple
         if not isinstance(variables, tuple):
             variables = (variables,)
+=======
+        if lower is not None:
+            lower_ = tf.cast(lower, config.dtype)
+            Distribution.logp = tf.select(tf.less(variables, lower_),
+                    tf.fill(tf.shape(variables), tf.constant(-np.inf, dtype=config.dtype)),
+                    Distribution.logp)
+
+        if upper is not None:
+            upper_ = tf.cast(upper, config.dtype)
+            Distribution.logp = tf.select(tf.greater(variables, upper_),
+                    tf.fill(tf.shape(variables), tf.constant(-np.inf, dtype=config.dtype)),
+                    Distribution.logp)
+
+        if lower is not None and upper is not None:
+            Distribution.logp = Distribution.logp - tf.log(Distribution.integral(lower, upper))
+>>>>>>> Add support for MCMC
 
         # Ensure the distribution has set the required properties
         if Distribution.logp is None:

--- a/tensorprob/distributions/uniform.py
+++ b/tensorprob/distributions/uniform.py
@@ -1,3 +1,4 @@
+import numpy as np
 import tensorflow as tf
 
 from .. import config

--- a/tensorprob/model.py
+++ b/tensorprob/model.py
@@ -268,6 +268,16 @@ class Model(object):
         self.assign({k: v for k, v in zip(sorted(self._hidden.keys(), key=lambda x: x.name), out.x)})
         return out
 
+    def mcmc(self, *args, **kwargs):
+        sampler = kwargs.get('sampler')
+        samples = kwargs.get('samples')
+        self._set_data(args)
+
+        if sampler is None:
+            from .samplers import EmceeSampler
+            sampler = EmceeSampler(walkers=40, session=self.session)
+
+        return sampler.sample(list(self._hidden.values()), self._nll, samples=samples)
 
 __all__ = [
     Model,

--- a/tensorprob/model.py
+++ b/tensorprob/model.py
@@ -175,6 +175,11 @@ class Model(object):
             # hidden_logps contains a single value
             hidden_logps = [self._get_rewritten(self._description[v].logp) for v in self._hidden]
 
+            # Handle the case where we don't have observed variables.
+            # We define the probability to not observe anything as 1.
+            if not observed_logps:
+                observed_logps = [tf.constant(0, dtype=config.dtype)]
+
             self._pdf = tf.exp(tf.add_n(
                 observed_logps
             ))
@@ -182,6 +187,7 @@ class Model(object):
                 [tf.reduce_sum(logp) for logp in observed_logps] +
                 hidden_logps
             )
+
             variables = [self._hidden[k] for k in self._hidden_sorted]
             self._nll_grad = tf.gradients(self._nll, variables)
             for i, (v, g) in enumerate(zip(variables, self._nll_grad)):

--- a/tensorprob/samplers/__init__.py
+++ b/tensorprob/samplers/__init__.py
@@ -1,0 +1,3 @@
+
+from .base import BaseSampler
+from .emcee import EmceeSampler

--- a/tensorprob/samplers/base.py
+++ b/tensorprob/samplers/base.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+class BaseSampler(object):
+
+    def __init__(self, session=None):
+        self._session = session or tf.get_default_session()
+
+    def sample(self, variables, cost, gradient=None):
+        raise NotImplementedError
+
+    @property
+    def session(self):
+        return self._session
+
+    @session.setter
+    def session(self, session):
+        self._session = session

--- a/tensorprob/samplers/emcee.py
+++ b/tensorprob/samplers/emcee.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import tensorflow as tf
 import numpy as np
 

--- a/tensorprob/samplers/emcee.py
+++ b/tensorprob/samplers/emcee.py
@@ -28,22 +28,18 @@ class EmceeSampler(BaseSampler):
             if not isinstance(v, tf.Variable):
                 raise ValueError("Parameter {} is not a tensorflow variable".format(v))
 
-        self.fev = 0
         def objective(xs):
             feed_dict = { k: v for k, v in zip(variables, xs) }
             out = self.session.run(cost, feed_dict=feed_dict)
-            if self.fev % 1000 == 0:
-                print(self.fev)
-            self.fev += 1
-            print(out)
             if np.isnan(out):
                 return np.inf
             return -out
 
-        all_inits = self.emcee.utils.sample_ball(inits, [1e-2] * len(inits), self.walkers)
+        all_inits = self.emcee.utils.sample_ball(inits, [1e-1] * len(inits), self.walkers)
         sampler = self.emcee.EnsembleSampler(self.walkers, len(variables), objective)
 
         samples = 1 if samples is None else samples
+        sampler.random_state = np.random.mtrand.RandomState(np.random.randint(1)).get_state()
         pos, lnprob, rstate = sampler.run_mcmc(all_inits, samples)
-        return sampler.flatchain
+        return sampler.chain
 

--- a/tensorprob/samplers/emcee.py
+++ b/tensorprob/samplers/emcee.py
@@ -1,0 +1,49 @@
+import tensorflow as tf
+import numpy as np
+
+from .base import BaseSampler
+
+class EmceeSampler(BaseSampler):
+
+    def __init__(self, walkers=100, **kwargs):
+        try:
+            import emcee
+        except ImportError:
+            raise ImportError("The emcee package needs to be installed in order to use EmceeSampler")
+
+        self.emcee = emcee
+        self.walkers = walkers
+        super(EmceeSampler, self).__init__(**kwargs)
+
+    def sample(self, variables, cost, gradient=None, samples=None):
+        # Check if variables is iterable
+        try:
+            iter(variables)
+        except TypeError:
+            raise ValueError("Variables parameter is not iterable")
+
+        inits = self.session.run(variables)
+
+        for v in variables:
+            if not isinstance(v, tf.Variable):
+                raise ValueError("Parameter {} is not a tensorflow variable".format(v))
+
+        self.fev = 0
+        def objective(xs):
+            feed_dict = { k: v for k, v in zip(variables, xs) }
+            out = self.session.run(cost, feed_dict=feed_dict)
+            if self.fev % 1000 == 0:
+                print(self.fev)
+            self.fev += 1
+            print(out)
+            if np.isnan(out):
+                return np.inf
+            return -out
+
+        all_inits = self.emcee.utils.sample_ball(inits, [1e-2] * len(inits), self.walkers)
+        sampler = self.emcee.EnsembleSampler(self.walkers, len(variables), objective)
+
+        samples = 1 if samples is None else samples
+        pos, lnprob, rstate = sampler.run_mcmc(all_inits, samples)
+        return sampler.flatchain
+

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,0 +1,15 @@
+
+import numpy as np
+from tensorprob import Model, Normal, Uniform
+
+def test_mcmc():
+    with Model() as model:
+        x = Normal(0, 1)
+
+    np.random.seed(0)
+    model.observed()
+    model.initialize({
+        x: 0.0,
+    })
+    out = model.mcmc(samples=100)
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -185,12 +185,12 @@ def test_nll():
     model.observed(X)
 
     xs = np.linspace(-5, 5, 100)
-    out1 = -sum(st.norm.logpdf(xs, 0, 1))
     model.initialize({
         mu: 0,
         sigma: 1
     })
-    out2 = model.nll(xs)
+    out1 = model.nll(xs)
+    out2 = -sum(st.norm.logpdf(xs, 0, 1))
     assert_almost_equal(out1, out2, 10)
 
 


### PR DESCRIPTION
I've implemented a simple MCMC method using the emcee library.

This fixes #21.

It required returning `-inf` when a parameter is outside of its
bounds. I've also had some trouble with our models returning `nan`, which we should definitely fix.
I think it's best to raise an exception if the model produces `nan`, and then make sure that the default distributions do a good job of not running into problems.