### PR TITLE
Ensure variables, gradients and bounds remain ordered

### DIFF
--- a/tensorprob/config.py
+++ b/tensorprob/config.py
@@ -2,3 +2,5 @@ import numpy as np
 
 dtype = np.float64
 int_dtype = np.int64
+
+debug = False

--- a/tensorprob/distributions/exponential.py
+++ b/tensorprob/distributions/exponential.py
@@ -10,9 +10,9 @@ def Exponential(lambda_, name=None):
 
     Distribution.logp = tf.log(lambda_) - lambda_*X
 
-    def cdf(lim):
-        return tf.constant(1, dtype=config.dtype) - tf.exp(-lambda_*lim)
+    def integral(lower, upper):
+        return tf.exp(-lambda_*lower) - tf.exp(-lambda_*upper)
 
-    Distribution.integral = lambda lower, upper: cdf(upper) - cdf(lower)
+    Distribution.integral = integral
 
     return X

--- a/tensorprob/model.py
+++ b/tensorprob/model.py
@@ -134,7 +134,7 @@ class Model(object):
                 self._hidden[var] = tf.Variable(var.dtype.as_numpy_dtype(assign_dict[var]), name=var.name.split(':')[0])
         self.session.run(tf.initialize_variables(list(self._hidden.values())))
         # Sort the hidden variables so we can access them in a consistant order
-        self._hidden_sorted = sorted(self._hidden.values(), key=lambda v: v.name)
+        self._hidden_sorted = sorted(self._hidden.keys(), key=lambda v: v.name)
 
         all_vars = self._hidden.copy()
         all_vars.update(self._observed)
@@ -148,7 +148,8 @@ class Model(object):
 
             self._pdf = tf.exp(tf.add_n(logps))
             self._nll = -tf.add_n([tf.reduce_sum(logp) for logp in logps])
-            self._nll_grad = tf.gradients(self._nll, self._hidden_sorted)
+            variables = [self._hidden[k] for k in self._hidden_sorted]
+            self._nll_grad = tf.gradients(self._nll, variables)
 
         self.initialized = True
 

--- a/tensorprob/optimizers/scipy_lbfgsb.py
+++ b/tensorprob/optimizers/scipy_lbfgsb.py
@@ -16,7 +16,6 @@ class ScipyLBFGSBOptimizer(BaseOptimizer):
         self.callback = callback
 
     def minimize(self, variables, cost, gradient=None, bounds=None):
-        gradient = None
         # Check if variables is iterable
         try:
             iter(variables)
@@ -26,9 +25,6 @@ class ScipyLBFGSBOptimizer(BaseOptimizer):
         for v in variables:
             if not isinstance(v, tf.Variable):
                 raise ValueError("Parameter {} is not a tensorflow variable".format(v))
-
-        tmp = zip(variables, bounds)
-        variables, bounds = zip(*sorted(tmp, key=lambda v: v[0].name))
 
         inits = self._session.run(variables)
 
@@ -73,7 +69,6 @@ class ScipyLBFGSBOptimizer(BaseOptimizer):
                 min_bounds.append((lower, upper))
         else:
             min_bounds = None
-        print(min_bounds)
 
         self.niter = 0
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,6 +5,7 @@ import scipy.stats as st
 
 import tensorprob as tp
 
+
 def test_creation():
     model = tp.Model()
     with model:
@@ -99,9 +100,9 @@ def test_assign():
     model.observed(X)
     feed = {mu: 42, sigma: 1}
     model.initialize(feed)
-    model.assign({mu: 1, sigma:0})
-    model.assign({mu: -100, sigma:0})
-    assert model.state == {mu: -100, sigma:0}
+    model.assign({mu: 1, sigma: 0})
+    model.assign({mu: -100, sigma: 0})
+    assert model.state == {mu: -100, sigma: 0}
     model.assign(feed)
     assert model.state == feed
 
@@ -125,7 +126,8 @@ def test_assign_wrong_container():
         sigma = tp.Parameter(lower=0)
         X = tp.Normal(mu, sigma)
     model.observed(X)
-    model.assign([1,2,3])
+    model.assign([1, 2, 3])
+
 
 @raises(tp.model.ModelError)
 def test_observed_in_model():
@@ -135,5 +137,3 @@ def test_observed_in_model():
         sigma = tp.Parameter(lower=0)
         X = tp.Normal(mu, sigma)
         model.observed(X)
-
-


### PR DESCRIPTION
Previously the variables were sorted causing the bounds/gradient to be randomly shuffled. This PR sorts the variables when initialize is called and then uses that ordering when necessary.