### PR TITLE
Avoid cluttering the graph with assign ops

### DIFF
--- a/tensorprob/optimizers/scipy_lbfgsb.py
+++ b/tensorprob/optimizers/scipy_lbfgsb.py
@@ -79,7 +79,7 @@ class ScipyLBFGSBOptimizer(BaseOptimizer):
                     print('iter  ', '\t'.join([x.name.split(':')[0] for x in variables]))
                 print('{: 4d}   {}'.format(self.niter, '\t'.join(map(str, xs))))
             if self.callback is not None:
-                self.callback(xs, self.niter)
+                self.callback(xs)
 
         results = fmin_l_bfgs_b(objective, inits, fprime=gradient_, callback=callback, approx_grad=approx_grad, bounds=min_bounds)
 
@@ -91,5 +91,4 @@ class ScipyLBFGSBOptimizer(BaseOptimizer):
         ret.message = results[2]['task'].decode().lower()
         ret.success = results[2]['warnflag'] == 0
 
-        self.session.run([v.assign(x) for v, x in zip(variables, results[0])])
         return ret

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,6 +26,29 @@ def test_distribution_creation_global_graph():
     after = tf.get_default_graph().as_graph_def()
     assert before == after
 
+def test_internal_graph_no_growth():
+    # Calling assign or fit doesn't grow the execution graph
+    with tp.Model() as model:
+        mu = tp.Parameter()
+        sigma = tp.Parameter(lower=0)
+        X = tp.Normal(mu, sigma)
+
+    model.observed(X)
+    model.initialize({
+        mu: 1,
+        sigma: 1,
+    })
+
+    before = model.session.graph_def
+    model.assign({
+        mu: 0,
+        sigma: 2,
+    })
+    model.fit([1,2,3])
+    after = model.session.graph_def
+
+    assert before == after
+
 
 @raises(tp.model.ModelError)
 def test_distribution_creation_outside_with():


### PR DESCRIPTION
I've added some code to make sure that the internal graph doesn't grow when calling `assign` or `fit`.