### PR TITLE
Consider bounds when using the integral and pdf

### DIFF
--- a/tensorprob/distribution.py
+++ b/tensorprob/distribution.py
@@ -1,13 +1,10 @@
-from collections import Iterable, namedtuple
+from collections import Iterable
 
 import numpy as np
 import tensorflow as tf
 
 from . import utilities
-from .model import Description, Model, ModelError
-
-
-Region = namedtuple('Region', ['lower', 'upper'])
+from .model import Description, Model, ModelError, Region
 
 
 class DistributionError(Exception):
@@ -58,12 +55,6 @@ def Distribution(distribution_init):
 
         if Distribution.integral is None:
             raise NotImplementedError('Numeric integrals are not yet supported')
-
-        # Normalise the distribution's logp
-        if lower is not None and upper is not None:
-            Distribution.logp = (
-                Distribution.logp - tf.log(Distribution.integral(lower, upper))
-            )
 
         # Parse the bounds to be a list of lists of Regions
         try:

--- a/tensorprob/distribution.py
+++ b/tensorprob/distribution.py
@@ -76,9 +76,10 @@ def Distribution(distribution_init):
         # Force the logp to zero where the distribution is invalid
         for var, bound in zip(variables, bounds):
             # numpy can't check Tensor objects so check the class type first
-            if not isinstance(bound[0].lower, tf.Tensor) and np.isneginf(bound[0].lower) \
-                    and not isinstance(bound[0].upper, tf.Tensor) and np.isposinf(bound[0].upper):
-                continue
+            # TODO(chrisburr) Remove this comment?
+            # if not isinstance(bound[0].lower, tf.Tensor) and np.isneginf(bound[0].lower) \
+            #         and not isinstance(bound[0].upper, tf.Tensor) and np.isposinf(bound[0].upper):
+            #     continue
 
             # Force logp to negative infinity when outside the allowed bounds
             conditions = [tf.logical_and(tf.greater(var, l), tf.less(var, u)) for l, u in bound]

--- a/tensorprob/distribution.py
+++ b/tensorprob/distribution.py
@@ -76,14 +76,7 @@ def Distribution(distribution_init):
             for l, u in bound:
                 conditions.append(tf.logical_and(tf.greater(var, l), tf.less(var, u)))
 
-            if len(conditions) == 1:
-                continue
-                Distribution.logp = tf.select(
-                    conditions,
-                    Distribution.logp,
-                    tf.fill(tf.shape(var), config.dtype(-np.inf))
-                )
-            else:
+            if len(conditions) > 0:
                 condition = conditions[0]
                 for a in conditions[1:]:
                     condition = tf.logical_or(condition, a)

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -51,7 +51,8 @@ def Mix2(f, A, B, name=None):
             # the dictionary
             for key, value in list(Model._current_model._silently_replace.items()):
                 if value == dist:
-                    del Model._current_model._silently_replace[key]
+                    Model._current_model._silently_replace[value] = X
+                    del Model._current_model._silently_replace[key]  # TODO(chrisburr) Remove
                     Model._current_model._silently_replace[key] = X
                     if dist in Model._current_model._description:
                         del Model._current_model._description[dist]

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -2,7 +2,8 @@ import tensorflow as tf
 
 from .. import config
 from ..distribution import Distribution
-from ..model import Model
+from ..model import Model, Region
+from ..utilities import is_finite
 
 
 @Distribution
@@ -16,7 +17,29 @@ def Mix2(f, A, B, name=None):
     Distribution.logp = tf.log(f*tf.exp(a_logp) + (1-f)*tf.exp(b_logp))
 
     def integral(lower, upper):
-        return f*a_integral(lower, upper) + (1-f)*b_integral(lower, upper)
+        a_integrals = []
+        # if is_finite(bounds[0].lower) and is_finite(bounds[0].upper)
+        for a_lower, a_upper in a_bounds:
+            # Ignore this region if it's outside the current limits
+            if a_upper < lower or upper < a_lower:
+                continue
+            # Else keep the region, tightening the edges as reqired
+            a_integrals.append(a_integral(max(a_lower, lower), min(a_upper, upper)))
+
+        a_integrals = tf.add_n(a_integrals) if a_integrals else tf.constant(1, config.dtype)
+
+        b_integrals = []
+        # if is_finite(bounds[0].lower) and is_finite(bounds[0].upper)
+        for b_lower, b_upper in b_bounds:
+            # Ignore this region if it's outside the current limits
+            if b_upper < lower or upper < b_lower:
+                continue
+            # Else keep the region, tightening the edges as reqired
+            b_integrals.append(b_integral(max(b_lower, lower), min(b_upper, upper)))
+
+        b_integrals = tf.add_n(b_integrals) if b_integrals else tf.constant(1, config.dtype)
+
+        return f*a_integrals + (1-f)*b_integrals
 
     Distribution.integral = integral
 

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -29,7 +29,6 @@ def Mix2(f, A, B, name=None):
         a_integrals = tf.add_n(a_integrals) if a_integrals else tf.constant(1, config.dtype)
 
         b_integrals = []
-        # if is_finite(bounds[0].lower) and is_finite(bounds[0].upper)
         for b_lower, b_upper in b_bounds:
             # Ignore this region if it's outside the current limits
             if b_upper < lower or upper < b_lower:

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -15,7 +15,10 @@ def Mix2(f, A, B, name=None):
 
     Distribution.logp = tf.log(f*tf.exp(a_logp) + (1-f)*tf.exp(b_logp))
 
-    Distribution.integral = lambda l, u: tf.constant(1, dtype=config.dtype)
+    def integral(lower, upper):
+        return f*a_integral(lower, upper) + (1-f)*b_integral(lower, upper)
+
+    Distribution.integral = integral
 
     # Modify the current model to recognize that X and Y have been removed
     for dist in A, B:

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -18,7 +18,6 @@ def Mix2(f, A, B, name=None):
     def _integral(mix_bounds, sub_bounds, sub_integral):
         # Calculate the normalised logp
         integrals = []
-        # if is_finite(bounds[0].lower) and is_finite(bounds[0].upper)
         for (mix_lower, mix_upper), (sub_lower, sub_upper) in product(mix_bounds, sub_bounds):
             # Ignore this region if it's outside the current limits
             if sub_upper < mix_lower or mix_upper < sub_lower:
@@ -54,7 +53,6 @@ def Mix2(f, A, B, name=None):
             for key, value in list(Model._current_model._silently_replace.items()):
                 if value == dist:
                     Model._current_model._silently_replace[value] = X
-                    del Model._current_model._silently_replace[key]  # TODO(chrisburr) Remove
                     Model._current_model._silently_replace[key] = X
                     if dist in Model._current_model._description:
                         del Model._current_model._description[dist]

--- a/tensorprob/distributions/uniform.py
+++ b/tensorprob/distributions/uniform.py
@@ -8,7 +8,7 @@ from ..distribution import Distribution
 def Uniform(name=None):
     X = tf.placeholder(config.dtype, name=name)
 
-    Distribution.logp = tf.constant(0, dtype=config.dtype)
+    Distribution.logp = tf.fill(tf.shape(X), config.dtype(0))
 
     Distribution.integral = lambda lower, upper: tf.cast(upper, config.dtype) - tf.cast(lower, config.dtype)
 
@@ -19,7 +19,7 @@ def Uniform(name=None):
 def UniformInt(name=None):
     X = tf.placeholder(config.int_dtype, name=name)
 
-    Distribution.logp = tf.constant(0, dtype=config.dtype)
+    Distribution.logp = tf.fill(tf.shape(X), config.dtype(0))
 
     Distribution.integral = lambda lower, upper: tf.cast(tf.floor(upper) - tf.ceil(lower), config.dtype)
 

--- a/tensorprob/model.py
+++ b/tensorprob/model.py
@@ -74,14 +74,12 @@ class Model(object):
         with self._model_graph.as_default():
             for var, (logp, integral, bounds) in self._description.items():
                 def replace_inf(x):
-                    if isinstance(x, tf.Tensor):
-                        return x
-                    elif np.isposinf(x):
-                        return 1e250
-                    elif np.isneginf(x):
-                        return -1e250
-                    else:
-                        return x
+                    if not isinstance(x, tf.Tensor):
+                        if np.isposinf(x):
+                            return 1e250
+                        elif np.isneginf(x):
+                            return -1e250
+                    return x
 
                 logp -= tf.log(tf.add_n([integral(replace_inf(l), replace_inf(u)) for l, u in bounds]))
 

--- a/tensorprob/model.py
+++ b/tensorprob/model.py
@@ -2,11 +2,10 @@ from collections import namedtuple
 import logging
 logger = logging.getLogger('tensorprob')
 
-import numpy as np
 import tensorflow as tf
 
-from . import utilities
 from . import config
+from .utilities import classproperty, generate_name, is_finite
 
 
 # Used to specify valid ranges for variables
@@ -48,9 +47,9 @@ class Model(object):
 
         # Whether `model.initialize()` has been called
         self.initialized = False
-        self.name = name or utilities.generate_name(self.__class__)
+        self.name = name or generate_name(self.__class__)
 
-    @utilities.classproperty
+    @classproperty
     def current_model(self):
         if Model._current_model is None:
             raise ModelError("This can only be used inside a model environment")
@@ -163,9 +162,6 @@ class Model(object):
         all_vars.update(self._observed)
 
         # Get the nomalised list of log probabilites
-        def is_finite(obj):
-            return isinstance(obj, tf.Tensor) or np.isfinite(obj)
-
         logps = []
         with self._model_graph.as_default():
             for var in self._observed:

--- a/tensorprob/model.py
+++ b/tensorprob/model.py
@@ -100,8 +100,6 @@ class Model(object):
         # Modify the input dictionary to replace variables which have been
         # superseded with the use of combinators
         for k, v in self._silently_replace.items():
-            if v.name in input_map:
-                del input_map[v.name]
             input_map[k.name] = self._observed[v]
 
         with self.session.graph.as_default():

--- a/tensorprob/utilities.py
+++ b/tensorprob/utilities.py
@@ -1,5 +1,8 @@
 from collections import defaultdict, Iterable
+import itertools
 
+import numpy as np
+import tensorflow as tf
 from six.moves import zip_longest
 
 
@@ -45,3 +48,14 @@ def flatten(l):
                 yield sub
         else:
             yield el
+
+
+def is_finite(obj):
+    return isinstance(obj, tf.Tensor) or np.isfinite(obj)
+
+
+def pairwise(iterable):
+    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)

--- a/tests/distributions/test_combinators.py
+++ b/tests/distributions/test_combinators.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 
 from tensorprob import Model, Parameter, Normal, Exponential, Mix2

--- a/tests/distributions/test_combinators.py
+++ b/tests/distributions/test_combinators.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from tensorprob import Model, Parameter, Normal, Exponential, Mix2
+
+
+def test_mix2_fit():
+    with Model() as model:
+        mu = Parameter()
+        sigma = Parameter(lower=1)
+        a = Parameter(lower=0)
+        f = Parameter(lower=0, upper=1)
+
+        X1 = Normal(mu, sigma, bounds=[(-np.inf, 21), (22, np.inf)])
+        X2 = Exponential(a, bounds=[(-np.inf, 8), (10, np.inf)])
+        X12 = Mix2(f, X1, X2, bounds=[(6, 17), (18, 36)])
+
+    model.observed(X12)
+    model.initialize({
+        mu: 23,
+        sigma: 1.2,
+        a: 0.2,
+        f: 0.3,
+    })
+
+    # Generate some data to fit
+    np.random.seed(42)
+
+    exp_data = np.random.exponential(10, 2000000)
+    exp_data = exp_data[(exp_data < 8) | (10 < exp_data)]
+
+    # Include the data blinded by the Mix2 bounds as we use the len(norm1_data)
+    norm1_data = np.random.normal(19, 2, 1000000)
+    norm1_data = norm1_data[
+        ((6 < norm1_data) & (norm1_data < 17)) |
+        ((18 < norm1_data) & (norm1_data < 21)) |
+        ((22 < norm1_data) & (norm1_data < 36))
+    ]
+
+    data = np.concatenate([exp_data, norm1_data])
+    data = data[((6 < data) & (data < 17)) | ((18 < data) & (data < 36))]
+
+    model.fit(data)
+
+    assert model.state[mu] - 19 < 5e-2
+    assert model.state[sigma] - 2 < 5e-2
+    assert model.state[a] - 0.1 < 5e-4
+    assert model.state[f] - (len(norm1_data)/len(data)) < 5e-4

--- a/tests/distributions/test_combinators.py
+++ b/tests/distributions/test_combinators.py
@@ -25,11 +25,11 @@ def test_mix2_fit():
     # Generate some data to fit
     np.random.seed(42)
 
-    exp_data = np.random.exponential(10, 2000000)
+    exp_data = np.random.exponential(10, 200000)
     exp_data = exp_data[(exp_data < 8) | (10 < exp_data)]
 
     # Include the data blinded by the Mix2 bounds as we use the len(norm1_data)
-    norm1_data = np.random.normal(19, 2, 1000000)
+    norm1_data = np.random.normal(19, 2, 100000)
     norm1_data = norm1_data[
         ((6 < norm1_data) & (norm1_data < 17)) |
         ((18 < norm1_data) & (norm1_data < 21)) |
@@ -41,7 +41,7 @@ def test_mix2_fit():
 
     model.fit(data)
 
-    assert model.state[mu] - 19 < 5e-2
-    assert model.state[sigma] - 2 < 5e-2
+    assert model.state[mu] - 19 < 5e-3
+    assert model.state[sigma] - 2 < 5e-3
     assert model.state[a] - 0.1 < 5e-4
-    assert model.state[f] - (len(norm1_data)/len(data)) < 5e-4
+    assert model.state[f] - (len(norm1_data)/len(data)) < 5e-5

--- a/tests/distributions/test_uniform.py
+++ b/tests/distributions/test_uniform.py
@@ -14,18 +14,18 @@ def test_init():
         X7 = tp.Uniform(lower=X1, upper=X2)
 
 
-#@raises(ValueError)
-#def test_uniform_fail_lower():
-#    with tp.Model():
-#        X1 = tp.Uniform()
-#        X2 = tp.Uniform(lower=X1)
-#
-#
-#@raises(ValueError)
-#def test_uniform_fail_upper():
-#    with tp.Model() as model:
-#        X1 = tp.Uniform()
-#        X2 = tp.Uniform(upper=X1)
+# @raises(ValueError)
+# def test_uniform_fail_lower():
+#     with tp.Model():
+#         X1 = tp.Uniform()
+#         X2 = tp.Uniform(lower=X1)
+
+
+# @raises(ValueError)
+# def test_uniform_fail_upper():
+#     with tp.Model() as model:
+#         X1 = tp.Uniform()
+#         X2 = tp.Uniform(upper=X1)
 
 
 def test_pdf():
@@ -34,7 +34,7 @@ def test_pdf():
         X = tp.Uniform(lower=dummy, upper=1)
 
     m.observed(X)
-    m.initialize({ dummy: -2 })
+    m.initialize({dummy: -2})
 
     xs = np.linspace(-1, 1, 1)
     out1 = st.uniform.pdf(xs, -2, 3)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,5 +1,7 @@
 import numpy as np
+import scipy.stats as st
 from nose.tools import raises
+from numpy.testing import assert_array_almost_equal
 
 from tensorprob import (
     config,
@@ -7,6 +9,8 @@ from tensorprob import (
     DistributionError,
     Model,
     ModelError,
+    Normal,
+    Parameter,
     Region,
 )
 import tensorflow as tf
@@ -94,6 +98,17 @@ def test_bounds_invalid_shape_2():
         ])
 
 
+@raises(ValueError)
+def test_bounds_contain_none():
+    FakeDistribution2D = get_fake_distribution(dimension=2)
+    with Model():
+        FakeDistribution2D(bounds=[
+            [1.1, 2.2, 3.3, 4.4],
+            [1.1, None, 3.3, 4.4],
+            [1.1, 2.2, 3.3, 4.4]
+        ])
+
+
 def test_bounds_1D():
     FakeDistribution = get_fake_distribution()
     with Model() as model:
@@ -147,3 +162,36 @@ def test_bounds_ND():
     assert model._description[F1].bounds == [Region(1.1, 2.1), Region(3.1, 4.1), Region(5.1, 6.1)]
     assert model._description[F2].bounds == [Region(1.2, 2.2), Region(3.2, 4.2), Region(5.2, 6.2)]
     assert model._description[F3].bounds == [Region(1.3, 2.3), Region(3.3, 4.3), Region(5.3, 6.3)]
+
+
+def test_integral():
+    bounds = [
+        (-1, -0.9), (-0.65, -0.5), (-0.4, -0.32),
+        (-0.31, -0.1), (0, 0.05), (0.2, np.inf)
+    ]
+
+    @np.vectorize
+    def allowed_point(x):
+        for l, u in bounds:
+            if l < x and x < u:
+                return 1
+        return 0
+
+    with Model() as model:
+        mu = Parameter()
+        sigma = Parameter(lower=0)
+        X = Normal(mu, sigma, bounds=bounds)
+
+    model.observed(X)
+    model.initialize({mu: -0.4, sigma: 2})
+
+    xs = np.linspace(-1, 1, 1001)
+
+    # Calculate the integral using scipy, zeroing points that are out of bounds
+    out1 = st.norm.pdf(xs, -0.4, 2) * allowed_point(xs)
+    integral = sum(st.norm.cdf(u, -0.4, 2) - st.norm.cdf(l, -0.4, 2) for l, u in bounds)
+    out1 /= integral
+
+    out2 = model.pdf(xs)
+
+    assert_array_almost_equal(out1, out2, 15)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -18,11 +18,13 @@ def get_fake_distribution(logp=-42, integral=-42, dimension=1):
             return tf.constant(2, dtype=config.dtype)
 
     def FakeDistribution(name=None):
+        FakeDistribution.name = name
+
         if logp == -42:
             Distribution.logp = tf.constant(1, dtype=config.dtype)
+        else:
+            Distribution.logp = logp
 
-        FakeDistribution.name = name
-        Distribution.logp = logp
         Distribution.integral = integral
         variables = tuple(tf.placeholder(config.dtype) for i in range(dimension))
         return variables

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -171,6 +171,7 @@ def test_observed_in_model():
         X = tp.Normal(mu, sigma)
         model.observed(X)
 
+
 def test_variable_independent():
     with tp.Model() as model:
         a = tp.Parameter()
@@ -179,5 +180,4 @@ def test_variable_independent():
     model.initialize({
         a: 1,
     })
-    model.fit([1,2,3])
-
+    model.fit([1, 2, 3])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -21,8 +21,8 @@ def test_scalar_creation_outside_with():
 def test_distribution_creation_global_graph():
     # Distribution creation doesn't modify the global graph
     before = tf.get_default_graph().as_graph_def()
-    with tp.Model() as model:
-        mu = tp.Parameter()
+    with tp.Model():
+        tp.Parameter()
     after = tf.get_default_graph().as_graph_def()
     assert before == after
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,6 +26,7 @@ def test_distribution_creation_global_graph():
     after = tf.get_default_graph().as_graph_def()
     assert before == after
 
+
 def test_internal_graph_no_growth():
     # Calling assign or fit doesn't grow the execution graph
     with tp.Model() as model:
@@ -44,7 +45,7 @@ def test_internal_graph_no_growth():
         mu: 0,
         sigma: 2,
     })
-    model.fit([1,2,3])
+    model.fit([1, 2, 3])
     after = model.session.graph_def
 
     assert before == after


### PR DESCRIPTION
Corrects the usage of bounds to ensure the integral is correct and the pdf is zeroed. See [this notebook](http://nbviewer.jupyter.org/gist/chrisburr/f0590f761e9e237616c2) for and example

Fixes #36.