### PR TITLE
Implement migrad as an optimization backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
     - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
-    - conda create --yes -n test_env python="$TRAVIS_PYTHON_VERSION" gcc=4.8 numpy scipy nose pip wheel
+    - conda create --yes -n test_env python="$TRAVIS_PYTHON_VERSION" gcc=4.8 numpy scipy nose pip wheel cython
     - source ~/miniconda/bin/activate test_env
     - pip install ghp-import mkdocs coverage coveralls colorlog emcee git+https://github.com/chrisburr/iminuit@add-gradient-rebased
     - export LD_LIBRARY_PATH=~/miniconda/envs/test_env/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - conda config --set always_yes yes --set changeps1 no
     - conda create --yes -n test_env python="$TRAVIS_PYTHON_VERSION" gcc=4.8 numpy scipy nose pip wheel
     - source ~/miniconda/bin/activate test_env
-    - pip install ghp-import mkdocs coverage coveralls colorlog emcee
+    - pip install ghp-import mkdocs coverage coveralls colorlog emcee iminuit
     - export LD_LIBRARY_PATH=~/miniconda/envs/test_env/lib
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
           pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.7.0-py2-none-linux_x86_64.whl;

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - conda config --set always_yes yes --set changeps1 no
     - conda create --yes -n test_env python="$TRAVIS_PYTHON_VERSION" gcc=4.8 numpy scipy nose pip wheel
     - source ~/miniconda/bin/activate test_env
-    - pip install ghp-import mkdocs coverage coveralls colorlog emcee iminuit
+    - pip install ghp-import mkdocs coverage coveralls colorlog emcee git+https://github.com/chrisburr/iminuit@add-gradient-rebased
     - export LD_LIBRARY_PATH=~/miniconda/envs/test_env/lib
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
           pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.7.0-py2-none-linux_x86_64.whl;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tensorflow==0.7.0
 colorlog
 emcee
+iminuit

--- a/tensorprob/optimizers/__init__.py
+++ b/tensorprob/optimizers/__init__.py
@@ -1,2 +1,3 @@
 from .base import BaseOptimizer
 from .scipy_lbfgsb import ScipyLBFGSBOptimizer
+from .migrad import MigradOptimizer

--- a/tensorprob/optimizers/base.py
+++ b/tensorprob/optimizers/base.py
@@ -1,11 +1,71 @@
+import numpy as np
+import tensorflow as tf
+from .. import config
 
 class BaseOptimizer(object):
 
-    def __init__(self):
+    def __init__(self, session=None):
+        self._session = session or tf.Session()
+
+    def minimize_impl(self, objective, gradient, inits, bounds):
         raise NotImplementedError
 
-    def minimize(self, cost, gradient=None, variables=None):
-        raise NotImplementedError
+    def minimize(self, variables, cost, gradient=None, bounds=None):
+        # Check if variables is iterable
+        try:
+            iter(variables)
+        except TypeError:
+            raise ValueError("Variables parameter is not iterable")
+
+        for v in variables:
+            if not isinstance(v, tf.Variable):
+                raise ValueError("Parameter {} is not a tensorflow variable".format(v))
+
+        inits = self._session.run(variables)
+
+        def objective(xs):
+            feed_dict = {k: v for k, v in zip(variables, xs)}
+            # Cast just in case the user-supplied function returns something else
+            val = np.float64(self._session.run(cost, feed_dict=feed_dict))
+            if config.debug:
+                print('objective', val, xs)
+            return val
+
+        if gradient is not None:
+            def gradient_(xs):
+                feed_dict = {k: v for k, v in zip(variables, xs)}
+                # Cast just in case the user-supplied function returns something else
+                val = np.array(self._session.run(gradient, feed_dict=feed_dict))
+                if config.debug:
+                    print('gradient', val, xs)
+                return val
+            approx_grad = False
+        else:
+            gradient_ = None
+
+        if bounds:
+            min_bounds = []
+            for current in bounds:
+                lower, upper = current
+
+                # Translate inf to None, which is what this minimizer understands
+                if lower is not None and np.isinf(lower):
+                    lower = None
+                if upper is not None and np.isinf(upper):
+                    upper = None
+                # This optimizer likes to evaluate the function at the boundaries.
+                # Slightly move the bounds so that the edges are not included.
+                if lower is not None:
+                    lower = lower + 1e-10
+                if upper is not None:
+                    upper = upper - 1e-10
+
+                min_bounds.append((lower, upper))
+        else:
+            min_bounds = None
+
+        return self.minimize_impl(objective, gradient_, inits, min_bounds)
+
 
     @property
     def session(self):

--- a/tensorprob/optimizers/base.py
+++ b/tensorprob/optimizers/base.py
@@ -1,6 +1,13 @@
+
+from collections import Iterable
+import logging
 import numpy as np
 import tensorflow as tf
 from .. import config
+
+
+logger = logging.getLogger('tensorprob')
+
 
 class BaseOptimizer(object):
 
@@ -8,13 +15,11 @@ class BaseOptimizer(object):
         self._session = session or tf.Session()
 
     def minimize_impl(self, objective, gradient, inits, bounds):
-        raise NotImplementedError
+            raise NotImplementedError
 
     def minimize(self, variables, cost, gradient=None, bounds=None):
         # Check if variables is iterable
-        try:
-            iter(variables)
-        except TypeError:
+        if not isinstance(variables, Iterable):
             raise ValueError("Variables parameter is not iterable")
 
         for v in variables:
@@ -27,8 +32,7 @@ class BaseOptimizer(object):
             feed_dict = {k: v for k, v in zip(variables, xs)}
             # Cast just in case the user-supplied function returns something else
             val = np.float64(self._session.run(cost, feed_dict=feed_dict))
-            if config.debug:
-                print('objective', val, xs)
+            logger.debug('Objective: {} {}'.format(val, xs))
             return val
 
         if gradient is not None:
@@ -36,8 +40,7 @@ class BaseOptimizer(object):
                 feed_dict = {k: v for k, v in zip(variables, xs)}
                 # Cast just in case the user-supplied function returns something else
                 val = np.array(self._session.run(gradient, feed_dict=feed_dict))
-                if config.debug:
-                    print('gradient', val, xs)
+                logger.debug('Gradient: {} {}'.format(val, xs))
                 return val
             approx_grad = False
         else:

--- a/tensorprob/optimizers/base.py
+++ b/tensorprob/optimizers/base.py
@@ -14,7 +14,7 @@ class BaseOptimizer(object):
         self._session = session or tf.Session()
 
     def minimize_impl(self, objective, gradient, inits, bounds):
-            raise NotImplementedError
+        raise NotImplementedError
 
     def minimize(self, variables, cost, gradient=None, bounds=None):
         # Check if variables is iterable

--- a/tensorprob/optimizers/base.py
+++ b/tensorprob/optimizers/base.py
@@ -1,4 +1,3 @@
-
 from collections import Iterable
 import logging
 import numpy as np
@@ -50,6 +49,9 @@ class BaseOptimizer(object):
             min_bounds = []
             for current in bounds:
                 lower, upper = current
+
+                if isinstance(lower, tf.Tensor) or isinstance(upper, tf.Tensor):
+                    raise NotImplementedError("Specifying variable bounds to optimizers is not yet supported")
 
                 # Translate inf to None, which is what this minimizer understands
                 if lower is not None and np.isinf(lower):

--- a/tensorprob/optimizers/migrad.py
+++ b/tensorprob/optimizers/migrad.py
@@ -32,17 +32,15 @@ class MigradOptimizer(BaseOptimizer):
 
         x0 = dict()
 
-        if self.verbose:
-            print_level = 2
-        else:
-            print_level = 0
+        print_level = 2 if self.verbose else 0
 
         names = ['var_{}'.format(i) for i in range(len(inits))]
 
-        for n, x in zip(names, inits):
+        for n, x, bound in zip(names, inits, bounds):
             x0[n] = x
             # TODO use a method to set this correctly
             x0['error_' + n] = 1
+            x0['limit_' + n] = bound
 
         all_kwargs = dict()
         all_kwargs.update(x0)
@@ -62,15 +60,20 @@ class MigradOptimizer(BaseOptimizer):
                 return 1e10
             return val
 
-        m = self.iminuit.Minuit(Min_Func(objective_, names), grad_fcn=mygrad_func, print_level=print_level, errordef=1, **all_kwargs)
+        m = self.iminuit.Minuit(
+                Min_Func(objective_, names),
+                grad_fcn=mygrad_func,
+                print_level=print_level,
+                errordef=1,
+                **all_kwargs
+        )
+
         m.set_strategy(2)
         a, b = m.migrad()
 
         x = []
         for name in names:
             x.append(m.values[name])
-
-        print(a)
 
         return OptimizationResult(
             x=x,

--- a/tensorprob/optimizers/migrad.py
+++ b/tensorprob/optimizers/migrad.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import
+
+import numpy as np
+from .base import BaseOptimizer
+from ..optimization_result import OptimizationResult
+
+class Min_Func:
+    def __init__(self, f, names):
+        from iminuit.util import make_func_code
+        self.f = f
+        self.func_code = make_func_code(names)
+        self.func_defaults = None
+
+    def __call__(self, *args):
+        return self.f(args)
+
+
+class MigradOptimizer(BaseOptimizer):
+
+    def __init__(self, verbose=False, **kwargs):
+        try:
+            import iminuit
+        except ImportError:
+            raise ImportError("The iminuit package needs to be installed in order to use MigradOptimizer")
+        self.iminuit = iminuit
+
+        self.verbose=verbose
+
+        super(MigradOptimizer, self).__init__(**kwargs)
+
+    def minimize_impl(self, objective, gradient, inits, bounds):
+
+        x0 = dict()
+
+        if self.verbose:
+            print_level = 2
+        else:
+            print_level = 0
+
+        names = ['var_{}'.format(i) for i in range(len(inits))]
+
+        for n, x in zip(names, inits):
+            x0[n] = x
+            # TODO use a method to set this correctly
+            x0['error_' + n] = 1
+
+        all_kwargs = dict()
+        all_kwargs.update(x0)
+
+        if gradient:
+            def mygrad_func(*x):
+                out = gradient(x)
+                return out
+        else:
+            mygrad_func = None
+
+        def objective_(x):
+            val = objective(x)
+            if np.isnan(val):
+                return 1e10
+            if np.isinf(val):
+                return 1e10
+            return val
+
+        m = self.iminuit.Minuit(Min_Func(objective_, names), grad_fcn=mygrad_func, print_level=print_level, errordef=1, **all_kwargs)
+        m.set_strategy(2)
+        a, b = m.migrad()
+
+        x = []
+        for name in names:
+            x.append(m.values[name])
+
+        print(a)
+
+        return OptimizationResult(
+            x=x,
+            err=m.errors,
+            func=a['fval'],
+            edm=a['edm'],
+            calls=a['nfcn'],
+            success=a['is_valid'],
+            has_valid_parameters=a['has_valid_parameters'],
+        )
+
+    @property
+    def session(self):
+        return self._session
+
+    @session.setter
+    def session(self, session):
+        self._session = session

--- a/tensorprob/optimizers/migrad.py
+++ b/tensorprob/optimizers/migrad.py
@@ -61,11 +61,11 @@ class MigradOptimizer(BaseOptimizer):
             return val
 
         m = self.iminuit.Minuit(
-                Min_Func(objective_, names),
-                grad_fcn=mygrad_func,
-                print_level=print_level,
-                errordef=1,
-                **all_kwargs
+            Min_Func(objective_, names),
+            grad_fcn=mygrad_func,
+            print_level=print_level,
+            errordef=1,
+            **all_kwargs
         )
 
         m.set_strategy(2)

--- a/tensorprob/optimizers/migrad.py
+++ b/tensorprob/optimizers/migrad.py
@@ -36,14 +36,16 @@ class MigradOptimizer(BaseOptimizer):
 
         names = ['var_{}'.format(i) for i in range(len(inits))]
 
-        for n, x, bound in zip(names, inits, bounds):
-            x0[n] = x
-            # TODO use a method to set this correctly
-            x0['error_' + n] = 1
-            x0['limit_' + n] = bound
-
         all_kwargs = dict()
-        all_kwargs.update(x0)
+
+        for n, x in zip(names, inits):
+            all_kwargs[n] = x
+            # TODO use a method to set this correctly
+            all_kwargs['error_' + n] = 1
+
+        if bounds:
+            for n, b in zip(names, bounds):
+                all_kwargs['limit_' + n] = b
 
         if gradient:
             def mygrad_func(*x):
@@ -54,9 +56,7 @@ class MigradOptimizer(BaseOptimizer):
 
         def objective_(x):
             val = objective(x)
-            if np.isnan(val):
-                return 1e10
-            if np.isinf(val):
+            if np.isnan(val) or np.isinf(val):
                 return 1e10
             return val
 

--- a/tensorprob/optimizers/scipy_lbfgsb.py
+++ b/tensorprob/optimizers/scipy_lbfgsb.py
@@ -3,78 +3,27 @@ import numpy as np
 import tensorflow as tf
 from scipy.optimize import fmin_l_bfgs_b
 
-from .. import config
 from ..optimization_result import OptimizationResult
 from .base import BaseOptimizer
 
 
 class ScipyLBFGSBOptimizer(BaseOptimizer):
 
-    def __init__(self, session=None, verbose=False, callback=None, m=10, factr=1e3, pgtol=1e-3):
-        self._session = session or tf.Session()
+    def __init__(self, verbose=False, callback=None, m=10, factr=1e3, pgtol=1e-3, **kwargs):
         self.verbose = verbose
         self.callback = callback
         self.m = m
         self.factr = factr
         self.pgtol = pgtol
+        super(ScipyLBFGSBOptimizer, self).__init__(**kwargs)
 
-    def minimize(self, variables, cost, gradient=None, bounds=None):
-        # Check if variables is iterable
-        try:
-            iter(variables)
-        except TypeError:
-            raise ValueError("Variables parameter is not iterable")
-
-        for v in variables:
-            if not isinstance(v, tf.Variable):
-                raise ValueError("Parameter {} is not a tensorflow variable".format(v))
-
-        inits = self._session.run(variables)
-
-        def objective(xs):
-            feed_dict = {k: v for k, v in zip(variables, xs)}
-            # Cast just in case the user-supplied function returns something else
-            val = np.float64(self._session.run(cost, feed_dict=feed_dict))
-            if config.debug:
-                print('objective', val, xs)
-            return val
-
-        if gradient is not None:
-            def gradient_(xs):
-                feed_dict = {k: v for k, v in zip(variables, xs)}
-                # Cast just in case the user-supplied function returns something else
-                val = np.array(self._session.run(gradient, feed_dict=feed_dict))
-                if config.debug:
-                    print('gradient', val, xs)
-                return val
-            approx_grad = False
-        else:
-            gradient_ = None
+    def minimize_impl(self, objective, gradient, inits, bounds):
+        if gradient is None:
             approx_grad = True
-
-        if bounds:
-            min_bounds = []
-            for current in bounds:
-                lower, upper = current
-
-                # Translate inf to None, which is what this minimizer understands
-                if lower is not None and np.isinf(lower):
-                    lower = None
-                if upper is not None and np.isinf(upper):
-                    upper = None
-                # This optimizer likes to evaluate the function at the boundaries.
-                # Slightly move the bounds so that the edges are not included.
-                if lower is not None:
-                    lower = lower + 1e-10
-                if upper is not None:
-                    upper = upper - 1e-10
-
-                min_bounds.append((lower, upper))
         else:
-            min_bounds = None
+            approx_grad = False
 
         self.niter = 0
-
         def callback(xs):
             self.niter += 1
             if self.verbose:
@@ -88,12 +37,12 @@ class ScipyLBFGSBOptimizer(BaseOptimizer):
                 objective,
                 inits,
                 m=self.m,
-                fprime=gradient_,
+                fprime=gradient,
                 factr=self.factr,
                 pgtol=self.pgtol,
                 callback=callback,
                 approx_grad=approx_grad,
-                bounds=min_bounds,
+                bounds=bounds,
         )
 
         ret = OptimizationResult()

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,5 +1,5 @@
 
-from tensorprob import ScipyLBFGSBOptimizer
+from tensorprob import ScipyLBFGSBOptimizer, MigradOptimizer
 import numpy as np
 import tensorflow as tf
 from nose.tools import raises
@@ -10,16 +10,36 @@ def test_scipy_lbfgsb():
     sess.run(tf.initialize_variables([x]))
     optimizer = ScipyLBFGSBOptimizer(verbose=True, session=sess)
     # With gradient
-    results = optimizer.minimize([x], x**2, 2 * x)
+    results = optimizer.minimize([x], x**2, [2 * x])
     assert results.success
     # Without gradient
-    results = optimizer.minimize([x], 2 * x)
+    results = optimizer.minimize([x], x**2)
     assert results.success
     # Test callback
     def callback(xs):
         pass
     optimizer = ScipyLBFGSBOptimizer(verbose=True, session=sess, callback=callback)
     assert optimizer.minimize([x], x**2).success
+    @raises(ValueError)
+    def test_illegal_parameter_as_variable1():
+        optimizer.minimize([42], x**2)
+    test_illegal_parameter_as_variable1()
+    @raises(ValueError)
+    def test_illegal_parameter_as_variable2():
+        optimizer.minimize(42, x**2)
+    test_illegal_parameter_as_variable2()
+
+def test_migrad():
+    sess = tf.Session()
+    x = tf.Variable(np.float64(2), name='x')
+    sess.run(tf.initialize_variables([x]))
+    optimizer = MigradOptimizer(session=sess)
+    # With gradient
+    results = optimizer.minimize([x], x**2, [2 * x])
+    assert results.success
+    # Without gradient
+    results = optimizer.minimize([x], x**2)
+    assert results.success
     @raises(ValueError)
     def test_illegal_parameter_as_variable1():
         optimizer.minimize([42], x**2)


### PR DESCRIPTION
I moved as much generic code as I could from the existing scipy optimizer into
`BaseOptimizer`.
I then implemented a new `MigradOptimizer` wrapper that uses
https://github.com/iminuit/iminuit/ internally.
I've also added a copy of the existing optimizer test for this backend.

This fixes #47.